### PR TITLE
fix 中文编码格式为 UTF-8

### DIFF
--- a/inc/mp3_tag.h
+++ b/inc/mp3_tag.h
@@ -67,12 +67,12 @@ typedef struct
  */
 typedef struct
 {
-    uint8_t id[4];      /* Ö¡ID,ÎªXing/Info */
-    uint8_t version[2]; /* °æ±¾ºÅ */
-    uint8_t delay[2];   /* ÑÓ³Ù */
-    uint8_t quality[2]; /* ÒôÆµÖÊÁ¿,0~100,Ô½´óÖÊÁ¿Ô½ºÃ */
-    uint8_t fsize[4];   /* ÎÄ¼ş×Ü´óĞ¡ */
-    uint8_t frames[4];  /* ÎÄ¼ş×ÜÖ¡Êı  */
+    uint8_t id[4];      /* å¸§IDï¼Œä¸ºXing/Info */
+    uint8_t version[2]; /* ç‰ˆæœ¬å· */
+    uint8_t delay[2];   /* å»¶è¿Ÿ */
+    uint8_t quality[2]; /* éŸ³é¢‘è´¨é‡ï¼Œ0~100ï¼Œè¶Šå¤§è´¨é‡è¶Šå¥½ */
+    uint8_t fsize[4];   /* æ–‡ä»¶æ€»å¤§å° */
+    uint8_t frames[4];  /* æ–‡ä»¶æ€»å¸§æ•° */
 } MP3_FrameVBRI_t;
 
 /**


### PR DESCRIPTION
在 VS Code 等编辑器使用 UTF-8 编码查看文件时会看到乱码。

```bash
$ git diff
diff --git a/inc/mp3_tag.h b/inc/mp3_tag.h
index 2545613..25bc49f 100644
--- a/inc/mp3_tag.h
+++ b/inc/mp3_tag.h
@@ -67,12 +67,12 @@ typedef struct
  */
 typedef struct
 {
-    uint8_t id[4];      /* ֡ID,ΪXing/Info */
-    uint8_t version[2]; /* <B0>汾<BA><C5> */
-    uint8_t delay[2];   /* <D1>ӳ<D9> */
-    uint8_t quality[2]; /* <D2><F4>Ƶ<D6><CA><C1><BF>,0~100,Խ<B4><F3><D6><CA><C1><BF>Խ<BA><C3> */
-    uint8_t fsize[4];   /* <CE>ļ<FE><D7>ܴ<F3>С */
-    uint8_t frames[4];  /* <CE>ļ<FE><D7><DC>֡<CA><FD>  */
+    uint8_t id[4];      /* 帧ID，为Xing/Info */
+    uint8_t version[2]; /* 版本号 */
+    uint8_t delay[2];   /* 延迟 */
+    uint8_t quality[2]; /* 音频质量，0~100，越大质量越好 */
+    uint8_t fsize[4];   /* 文件总大小 */
+    uint8_t frames[4];  /* 文件总帧数 */
 } MP3_FrameVBRI_t;
 
 /**
```