### PR TITLE
After rt-thread V5.0,api rt_mq_recv changed the return parameter

### DIFF
--- a/src/mp3_player.c
+++ b/src/mp3_player.c
@@ -406,7 +406,11 @@ static int mp3_player_event_handler(struct mp3_player *player, int timeout)
 #endif
 
     result = rt_mq_recv(player->mq, &msg, sizeof(struct play_msg), timeout);
-    if (result != RT_EOK)
+    #if RT_VERSION_CHECK(RT_VERSION_MAJOR,RT_VERSION_MINOR,RT_VERSION_PATCH) > 50000
+    if (!result)
+    #else
+    if (RT_EOK != result)
+    #endif
     {
         event = PLAYER_EVENT_NONE;
         return event;


### PR DESCRIPTION
修复rt_mq_recv 返回参数的修改后，导致无法播放的问题，兼容V5.0以上的版本