### PR TITLE
使用RT_VER_NUM宏判断内核版本，兼容rt-thread5.0以上版本，rt_mq_recv返回值的问题

### DIFF
--- a/src/mp3_player.c
+++ b/src/mp3_player.c
@@ -406,7 +406,7 @@ static int mp3_player_event_handler(struct mp3_player *player, int timeout)
 #endif
 
     result = rt_mq_recv(player->mq, &msg, sizeof(struct play_msg), timeout);
-    #if RT_VERSION_CHECK(RT_VERSION_MAJOR,RT_VERSION_MINOR,RT_VERSION_PATCH) > 50000
+    #if RT_VER_NUM > 0x50000
     if (!result)
     #else
     if (RT_EOK != result)


### PR DESCRIPTION
使用RT_VER_NUM宏判断内核版本，兼容性更好